### PR TITLE
Add text color to nk-error/success messages

### DIFF
--- a/src/components/nk-error-message/nk-error-message.css
+++ b/src/components/nk-error-message/nk-error-message.css
@@ -8,13 +8,12 @@
   line-height: 20px;
   letter-spacing: 0.15px;
   text-align: left;
-
 }
 
 .error {
-  background: linear-gradient(0deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.9)), #F44336;
+  background: linear-gradient(0deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.9)), #f44336;
   border-radius: 4px;
-
+  color: #f44336;
 
   position: relative;
   padding: 0.75rem 1.25rem;

--- a/src/components/nk-success-message/nk-success-message.css
+++ b/src/components/nk-success-message/nk-success-message.css
@@ -8,13 +8,12 @@
   line-height: 20px;
   letter-spacing: 0.15px;
   text-align: left;
-
 }
 
 .success {
-  background: linear-gradient(0deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.9)), #4CAF50;
+  background: linear-gradient(0deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.9)), #4caf50;
   border-radius: 4px;
-
+  color: #4caf50;
 
   position: relative;
   padding: 0.75rem 1.25rem;


### PR DESCRIPTION
Wondering if we can add text color to the messages. I've see a few sites with dark background and the message color is inherited so it's not visible/white on the light message background.

<img width="326" alt="Screen Shot 2022-08-25 at 1 32 03 PM" src="https://user-images.githubusercontent.com/1714294/186763528-f1339e27-f6cd-400f-8c39-4dc66d911d6b.png">

<img width="590" alt="Screen Shot 2022-08-25 at 1 29 43 PM" src="https://user-images.githubusercontent.com/1714294/186763542-dd455bab-cadd-44aa-a04f-95bb380c596e.png">
